### PR TITLE
Fix three critical code bugs

### DIFF
--- a/answer_diversity.py
+++ b/answer_diversity.py
@@ -141,9 +141,9 @@ def main():
         print(f"Directory {rollouts_dir} does not exist!")
         return
     
-    # Find files 1.jsonl through 51.jsonl
+    # Find files 1.jsonl through 64.jsonl
     jsonl_files = []
-    for i in range(2, 65 ):  # 1 to 51 inclusive
+    for i in range(1, 65):  # 1 to 64 inclusive
         target_file = rollouts_dir / f"{i}.jsonl"
         if target_file.exists():
             jsonl_files.append(target_file)
@@ -151,10 +151,10 @@ def main():
             print(f"Warning: File {target_file} does not exist, skipping...")
     
     if not jsonl_files:
-        print("No .jsonl files found in the range 1-51!")
+        print("No .jsonl files found in the range 1-64!")
         return
     
-    print(f"Found {len(jsonl_files)} files to process (range 1-51)")
+    print(f"Found {len(jsonl_files)} files to process (range 1-64)")
     
     # Initialize storage for statistics
     file_stats = {

--- a/recipe/langgraph_agent/example/math_expression.py
+++ b/recipe/langgraph_agent/example/math_expression.py
@@ -29,7 +29,14 @@ def calculate(a: int, b: int, operand: str) -> int:
     assert operand in ["+", "-", "*", "@"], f"unknown operand {operand}"
     if operand == "@":
         return 3 * a - 2 * b
-    return eval(f"{a} {operand} {b}")
+    if operand == "+":
+        return a + b
+    if operand == "-":
+        return a - b
+    if operand == "*":
+        return a * b
+    # Should never reach here due to assert
+    raise ValueError(f"Unsupported operand: {operand}")
 
 
 class MathExpressionReactAgentLoop(ReactAgentLoop):

--- a/scripts/diagnose.py
+++ b/scripts/diagnose.py
@@ -152,7 +152,8 @@ def check_network(args):
     print("----------Network Test----------")
     if args.timeout > 0:
         print("Setting timeout: {}".format(args.timeout))
-        socket.setdefaulttimeout(10)
+        # Honor the user-provided timeout rather than a hardcoded value
+        socket.setdefaulttimeout(args.timeout)
     for region in args.region.strip().split(","):
         r = region.strip().lower()
         if not r:

--- a/talk_to_model.py
+++ b/talk_to_model.py
@@ -34,12 +34,13 @@ def format_chat_message(tokenizer, messages):
         formatted += "Assistant: "
         return formatted
 
-def generate_response(model, tokenizer, prompt, max_new_tokens=512, temperature=0.7, do_sample=True):
+def generate_response(model, tokenizer, prompt, max_new_tokens=512, temperature=0.7, do_sample=True, device="auto"):
     """Generate response from the model"""
     # Tokenize input
     inputs = tokenizer(prompt, return_tensors="pt")
     
-    if torch.cuda.is_available():
+    # Respect the requested device when moving inputs
+    if device == "cuda" and torch.cuda.is_available():
         inputs = {k: v.to('cuda') for k, v in inputs.items()}
     
     # Generate
@@ -49,7 +50,7 @@ def generate_response(model, tokenizer, prompt, max_new_tokens=512, temperature=
             max_new_tokens=max_new_tokens,
             temperature=temperature,
             do_sample=do_sample,
-            pad_token_id=tokenizer.eos_token_id,
+            pad_token_id=(tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id),
             repetition_penalty=1.1
         )
     
@@ -60,12 +61,12 @@ def generate_response(model, tokenizer, prompt, max_new_tokens=512, temperature=
 
 def main():
     parser = argparse.ArgumentParser(description='Chat with or complete text using local HF models')
-    parser.add_argument('--model-path', help='Path to HF model directory')
+    parser.add_argument('--model-path', required=True, help='Path to HF model directory')
     parser.add_argument('--completion', default=False,  action='store_true', help='Single completion mode instead of chat')
     parser.add_argument('--max-tokens', type=int, default=2048, help='Max new tokens to generate')
     parser.add_argument('--temperature', type=float, default=0.7, help='Sampling temperature')
     parser.add_argument('--quantize', action='store_true', default=False, help='Use 4-bit quantization (requires bitsandbytes)')
-    parser.add_argument('--device', default='cuda', help='Device to use (auto, cpu, cuda)')
+    parser.add_argument('--device', default='cuda', choices=['auto', 'cpu', 'cuda'], help='Device to use (auto, cpu, cuda)')
     
     args = parser.parse_args()
     
@@ -74,11 +75,14 @@ def main():
     # Set up quantization if requested
     quantization_config = None
     if args.quantize:
-        quantization_config = BitsAndBytesConfig(
-            load_in_4bit=True,
-            bnb_4bit_quant_type="nf4",
-            bnb_4bit_compute_dtype=torch.float16,
-        )
+        if args.device != 'cuda' or not torch.cuda.is_available():
+            print("Quantization requires CUDA; disabling quantization since device is not CUDA or CUDA unavailable.")
+        else:
+            quantization_config = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_compute_dtype=torch.float16,
+            )
     
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(args.model_path)
@@ -87,11 +91,15 @@ def main():
     
     # Load model
     model_kwargs = {"quantization_config": quantization_config} if quantization_config else {}
-    if args.device != 'cpu' and torch.cuda.is_available():
+    if args.device in ['cuda', 'auto'] and torch.cuda.is_available():
         model_kwargs["torch_dtype"] = torch.float16
-        model_kwargs["device_map"] = "auto"
+        # Let accelerate infer device map when auto, or when quantization is enabled
+        if args.device == 'auto' or quantization_config is not None:
+            model_kwargs["device_map"] = "auto"
     
-    model = AutoModelForCausalLM.from_pretrained(args.model_path, **model_kwargs)
+    # Filter out None values to avoid passing them
+    model = AutoModelForCausalLM.from_pretrained(args.model_path, **{k: v for k, v in model_kwargs.items() if v is not None})
+    model.eval()
     
     # Detect if this is a chat model
     is_chat_model = detect_chat_template(tokenizer, args.model_path)
@@ -106,7 +114,7 @@ def main():
         print(repr(prompt))
         print(f"=== END INPUT ({len(tokenizer.encode(prompt))} tokens) ===\n")
         
-        response = generate_response(model, tokenizer, prompt, args.max_tokens, args.temperature)
+        response = generate_response(model, tokenizer, prompt, args.max_tokens, args.temperature, device=args.device)
         print(f"Generated: {response}")
         
     else:
@@ -142,7 +150,7 @@ def main():
                 print(repr(full_prompt))
                 print(f"=== END INPUT ({len(tokenizer.encode(full_prompt))} tokens) ===\n")
                 
-                response = generate_response(model, tokenizer, full_prompt, args.max_tokens, args.temperature)
+                response = generate_response(model, tokenizer, full_prompt, args.max_tokens, args.temperature, device=args.device)
                 print(f"Assistant: {response}\n")
                 
                 if is_chat_model:


### PR DESCRIPTION
### What does this PR do?

This PR addresses four distinct bugs across the codebase, improving security, reliability, and correctness:
1.  **Security Fix:** Replaces an unsafe `eval()` call in `recipe/langgraph_agent/example/math_expression.py` with explicit operator handling to prevent code injection.
2.  **Logic/Performance Fix:** Enhances `talk_to_model.py` to correctly respect the `--device` argument, handle `pad_token_id` robustly, make `--model-path` required, and properly manage 4-bit quantization based on device availability.
3.  **Correctness Fix:** Rectifies inconsistent file range processing and messaging in `answer_diversity.py` to ensure all intended JSONL files (1-64) are processed.
4.  **Reliability Fix:** Corrects `scripts/diagnose.py` to honor the user-specified network `--timeout` instead of using a hardcoded value.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: [https://github.com/volcengine/verl/pulls?q=is%3Apr+eval+security](https://github.com/volcengine/verl/pulls?q=is%3Apr+eval+security)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
    - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`
    `[recipe, model, training_utils, scripts] fix: Address security, device handling, range, and timeout bugs`

### Test

A lightweight compile/syntax check was performed on the modified files. Full unit tests were not run due to external dependency requirements, but the changes are targeted and aim to fix specific, isolated issues.

### API and Usage Example

The `talk_to_model.py` script's CLI arguments have been refined:
-   `--model-path` is now `required=True`.
-   `--device` now has explicit `choices=['auto', 'cpu', 'cuda']`.

Example usage for `talk_to_model.py`:
```bash
python talk_to_model.py --model-path /path/to/your/model --device cuda --quantize
```
The `math_expression.py`, `answer_diversity.py`, and `scripts/diagnose.py` changes are internal and do not alter their public API or CLI usage, beyond `scripts/diagnose.py` now correctly respecting the `--timeout` argument.

### Design & Code Changes

This PR implements the following specific changes:

1.  **`recipe/langgraph_agent/example/math_expression.py`**:
    *   Replaced `eval(f"{a} {operand} {b}")` with explicit `if/elif` statements for `+`, `-`, `*`, and `@` operands. This eliminates a potential code injection vulnerability.

2.  **`talk_to_model.py`**:
    *   Modified `generate_response` to accept a `device` argument and only move input tensors to CUDA if `device == "cuda"` and CUDA is available.
    *   Made `--model-path` a required argument.
    *   Restricted `--device` choices to `['auto', 'cpu', 'cuda']`.
    *   Updated `pad_token_id` usage in `model.generate` to prioritize `tokenizer.pad_token_id` if available, falling back to `tokenizer.eos_token_id`.
    *   Added logic to disable 4-bit quantization if `--device` is not `cuda` or CUDA is unavailable, as it's a CUDA-specific feature.
    *   Set `model_kwargs["device_map"] = "auto"` when `args.device == 'auto'` or quantization is enabled.
    *   Added `model.eval()` after loading the model for consistent inference behavior.

3.  **`answer_diversity.py`**:
    *   Adjusted the loop for finding JSONL files from `range(2, 65)` to `range(1, 65)` to include `1.jsonl`.
    *   Updated print statements to consistently refer to the file range "1-64".

4.  **`scripts/diagnose.py`**:
    *   Changed `socket.setdefaulttimeout(10)` to `socket.setdefaulttimeout(args.timeout)` within `check_network` to ensure the user-specified timeout is applied.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: A full unit test run requires additional dependencies (e.g., `omegaconf`, `bitsandbytes`) not readily available in a minimal environment. Lightweight syntax checks were performed.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)

---
<a href="https://cursor.com/background-agent?bcId=bc-c7bd4a53-110f-4e67-9794-e8006de99f1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7bd4a53-110f-4e67-9794-e8006de99f1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

